### PR TITLE
Updated navigation text for consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <a id="close"><i class="fas fa-times"></i></a>
         <br>
         <a href="index.html">Home</a>
-        <a href="docs/index.html">Get Started</a>
+        <a href="docs/index.html">Getting Started</a>
         <a href="https://github.com/zeva-ui/zeva">Github</a>
         <a href="https://github.com/zeva-ui/zeva/archive/master.zip">Download v1.0.0</a>
     </div>
@@ -37,7 +37,7 @@
                 <td style="width:70%;">
                     <nav id="notPhone">
                         <a href="index.html">Home</a>
-                        <a href="docs/index.html">Get Started</a>
+                        <a href="docs/index.html">Getting Started</a>
                         <a href="https://github.com/zeva-ui/zeva">Github</a>
                         <a href="https://github.com/zeva-ui/zeva/archive/v1.0.0.zip">Download v1.0.0</a>
                     </nav>


### PR DESCRIPTION
Changed "Get Started" to read "Getting Started" on the home page so it's consistent across all the pages. 

